### PR TITLE
New reading difficulty formula accounting for note density

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/sgab5r9nh1
+			// https://www.desmos.com/calculator/biltwjojyo
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
 
@@ -41,7 +42,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
 			
 			// https://www.desmos.com/calculator/r1ffltv1i6
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -44,8 +44,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
 			
-			// https://www.desmos.com/calculator/r1ffltv1i6
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);
+			// https://www.desmos.com/calculator/u63f3ntdsi
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -34,18 +34,21 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double effectiveBPM = noteObject.EffectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
-            var highVelocity = new VelocityRange(480, 660);
+            var highVelocity = new VelocityRange(480, 640);
+			
+			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// High velocity notes are penalised if their note density is high
-			// Density is worked out by taking the time between this note and the previous
+			// High velocity notes are penalised if they are close to other notes
+			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/biltwjojyo
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
+			// https://www.desmos.com/calculator/r1ffltv1i6
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.95, 15);
 			
-			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
-			double highVelDifficulty = (1.0 - 0.6 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, (highVelocity.Center + 30 * densityPenalty), 0.1 * (highVelocity.Range + 0.8 * densityPenalty));
+			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
+			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);
+			double highVelDifficulty = (1.0 - 0.33 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, midpointOffset, multiplier);
 			
             return midVelDifficulty + highVelDifficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -42,10 +42,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
-			
-			// https://www.desmos.com/calculator/u63f3ntdsi
-			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			double densityPenalty = 0.0;
+			if (effectiveBPM > 0 && noteObject.DeltaTime > 0)
+			{
+				double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+				// https://www.desmos.com/calculator/u63f3ntdsi
+				densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
+			}
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -41,8 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// Explain properly soon
-			// https://www.desmos.com/calculator/ftvspcqgqd
+			// https://www.desmos.com/calculator/mx4dyydxji
 			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
 
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,19 +33,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         {
             double effectiveBPM = noteObject.EffectiveBPM;
 
-            var highVelocity = new VelocityRange(480, 640);
-            var midVelocity = new VelocityRange(360, 480);
+			var midVelocity = new VelocityRange(360, 480);
+            var highVelocity = new VelocityRange(480, 660);
 
-			// High velocity notes are penalised if their note density is highVelDifficulty
+			// High velocity notes are penalised if their note density is high
 			// Density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
 			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
 			
-			// https://www.desmos.com/calculator/mx4dyydxji
-			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
-
+			// https://www.desmos.com/calculator/sgab5r9nh1
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 1, 15);
+			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
-			double highVelDifficulty = (1.0 - densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10));
+			double highVelDifficulty = (1.0 - 0.6 * densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, (highVelocity.Center + 30 * densityPenalty), 0.1 * (highVelocity.Range + 0.8 * densityPenalty));
 			
             return midVelDifficulty + highVelDifficulty;
         }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -36,8 +36,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             var highVelocity = new VelocityRange(480, 640);
             var midVelocity = new VelocityRange(360, 480);
 
-            return 1.0 * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10))
-                   + 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			// High velocity notes are penalised if their note density is highVelDifficulty
+			// Density is worked out by taking the time between this note and the previous
+			// and comparing it to the expected time at this note's effective BPM
+			double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
+			
+			// Explain properly soon
+			// https://www.desmos.com/calculator/ftvspcqgqd
+			double densityPenalty = 0.5 * DifficultyCalculationUtils.Logistic(density, 1, 15);
+
+			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
+			double highVelDifficulty = (1.0 - densityPenalty) * DifficultyCalculationUtils.Logistic(effectiveBPM, highVelocity.Center, 1.0 / (highVelocity.Range / 10));
+			
+            return midVelDifficulty + highVelDifficulty;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <returns>The reading difficulty value for the given hit object.</returns>
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
-            double effectiveBPM = noteObject.EffectiveBPM;
+            double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
@@ -42,13 +42,10 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 			// High velocity notes are penalised if they are close to other notes
 			// Note density is worked out by taking the time between this note and the previous
 			// and comparing it to the expected time at this note's effective BPM
-			double densityPenalty = 0.0;
-			if (effectiveBPM > 0 && noteObject.DeltaTime > 0)
-			{
-				double density = (21000.0 / effectiveBPM) / noteObject.DeltaTime;
-				// https://www.desmos.com/calculator/u63f3ntdsi
-				densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
-			}
+			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
+			
+			// https://www.desmos.com/calculator/u63f3ntdsi
+			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			
 			double midpointOffset = highVelocity.Center + 8 * densityPenalty;
 			double multiplier = (1.0 + 0.5 * densityPenalty) / (highVelocity.Range / 10);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,16 +33,17 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
             double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
-			// Effective BPM normalised such that base SV 1/4 is 1.0, 1/8 is 2.0 etc.
-			double normalisedBPM = 21000.0 / effectiveBPM;
+			// Expected deltatime is the deltatime this note would need
+			// to be spaced equally to a base SV 1/4 note
+			double expectedDeltaTime = 21000.0 / effectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// Density refers to an object's normalised BPM relative to its deltatime
-			double density = normalisedBPM / Math.Max(1.0, noteObject.DeltaTime);
+			// Density refers to an object's deltatime relative to its expected deltatime
+			double density = expectedDeltaTime / Math.Max(1.0, noteObject.DeltaTime);
 			
 			// Dense notes are penalised at high velocities
 			// https://www.desmos.com/calculator/u63f3ntdsi

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/ReadingEvaluator.cs
@@ -33,17 +33,18 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         public static double EvaluateDifficultyOf(TaikoDifficultyHitObject noteObject)
         {
             double effectiveBPM = Math.Max(1.0, noteObject.EffectiveBPM);
+			// Effective BPM normalised such that base SV 1/4 is 1.0, 1/8 is 2.0 etc.
+			double normalisedBPM = 21000.0 / effectiveBPM;
 
 			var midVelocity = new VelocityRange(360, 480);
             var highVelocity = new VelocityRange(480, 640);
 			
 			double midVelDifficulty = 0.5 * DifficultyCalculationUtils.Logistic(effectiveBPM, midVelocity.Center, 1.0 / (midVelocity.Range / 10));
 
-			// High velocity notes are penalised if they are close to other notes
-			// Note density is worked out by taking the time between this note and the previous
-			// and comparing it to the expected time at this note's effective BPM
-			double density = (21000.0 / effectiveBPM) / Math.Max(1.0, noteObject.DeltaTime);
+			// Density refers to an object's normalised BPM relative to its deltatime
+			double density = normalisedBPM / Math.Max(1.0, noteObject.DeltaTime);
 			
+			// Dense notes are penalised at high velocities
 			// https://www.desmos.com/calculator/u63f3ntdsi
 			double densityPenalty = DifficultyCalculationUtils.Logistic(density, 0.925, 15);
 			

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
         /// <summary>
         /// Calculates the difficulty of a given ratio using a combination of periodic penalties and bonuses.
         /// </summary>
-        private static double ratioDifficulty(double ratio, int terms = 8)
+        private static double ratioDifficulty(double ratio, int total = 1, int terms = 8)
         {
             double difficulty = 0;
 
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 difficulty += termPenalty(ratio, i, 2, 1);
             }
 
-            difficulty += terms / (1 + ratio);
+            difficulty += Math.Pow(terms / (1 + ratio), 1 / total);
 
             // Give bonus to near-1 ratios
             difficulty += DifficultyCalculationUtils.BellCurve(ratio, 1, 0.7);
@@ -128,7 +128,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
 
         private static double evaluateDifficultyOf(SamePatterns samePatterns)
         {
-            return ratioDifficulty(samePatterns.IntervalRatio);
+            return ratioDifficulty(samePatterns.IntervalRatio, samePatterns.Total);
         }
 
         /// <summary>
@@ -143,14 +143,14 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
             double samePattern = 0;
 
             if (rhythm.SameRhythmHitObjects?.FirstHitObject == hitObject) // Difficulty for SameRhythmHitObjects
-                sameRhythm = 5.5 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
+                sameRhythm = 9 * evaluateDifficultyOf(rhythm.SameRhythmHitObjects, hitWindow);
 
             if (rhythm.SamePatterns?.FirstHitObject == hitObject) // Difficulty for SamePatterns
                 samePattern += 2.5 * evaluateDifficultyOf(rhythm.SamePatterns);
 
             difficulty += Math.Max(sameRhythm, samePattern);
 
-            return difficulty;
+            return difficulty * 0.5;
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Evaluators/RhythmEvaluator.cs
@@ -34,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Evaluators
                 difficulty += termPenalty(ratio, i, 2, 1);
             }
 
-            difficulty += Math.Pow(terms / (1 + ratio), 1 / total);
+            difficulty += Math.Pow(terms / (1.0 + ratio), 1.0 / total);
 
             // Give bonus to near-1 ratios
             difficulty += DifficultyCalculationUtils.BellCurve(ratio, 1, 0.7);

--- a/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SamePatterns.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/Preprocessing/Rhythm/Data/SamePatterns.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty.Preprocessing.Rhythm.Data
 
         public TaikoDifficultyHitObject FirstHitObject => Children[0].FirstHitObject;
 
+        public int Total => Children.Sum(x => x.Children.Count);
+
         public IEnumerable<TaikoDifficultyHitObject> AllHitObjects => Children.SelectMany(child => child.Children);
 
         private SamePatterns(SamePatterns? previous, List<SameRhythmHitObjects> data, ref int i)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoDifficultyCalculator.cs
@@ -30,6 +30,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
         private const double stamina_skill_multiplier = 0.445 * difficulty_multiplier;
 
         private double strainLengthBonus;
+        
+        private double rhythmScale;
 
         public override int Version => 20241007;
 
@@ -121,6 +123,8 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             double rhythmDifficultStrains = rhythm.CountTopWeightedStrains();
             double staminaDifficultStrains = stamina.CountTopWeightedStrains() * clockRate;
 
+            rhythmScale = Math.Pow(staminaRating * colourRating, 0.28);
+
             strainLengthBonus = 1
                                 + Math.Min(Math.Max((staminaDifficultStrains - 1350) / 5000, 0), 0.15)
                                 + Math.Min(Math.Max((staminaRating - 7.0) / 1.0, 0), 0.05);
@@ -179,7 +183,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             for (int i = 0; i < colourPeaks.Count; i++)
             {
-                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier * strainLengthBonus;
+                double rhythmPeak = rhythmPeaks[i] * rhythm_skill_multiplier * strainLengthBonus * rhythmScale;
                 double readingPeak = readingPeaks[i] * reading_skill_multiplier;
                 double colourPeak = colourPeaks[i] * colour_skill_multiplier;
                 double staminaPeak = staminaPeaks[i] * stamina_skill_multiplier * strainLengthBonus;


### PR DESCRIPTION
These changes apply a penalty to "dense" notes at high velocity, aiming to nerf maps gaining lots of reading difficulty just by being exceptionally fast. A Desmos link is included. The changes are only to ReadingEvaluator.cs, the other files changed are because my branch was outdated